### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README-zh.md
+++ b/README-zh.md
@@ -198,3 +198,5 @@ The PlayCanvas Engine is released under the [MIT](https://opensource.org/license
 [twitter-badge]: https://img.shields.io/twitter/follow/playcanvas.svg?style=social&label=Follow
 [twitter-url]: https://twitter.com/intent/follow?screen_name=playcanvas
 [docs]: https://developer.playcanvas.com/en/api/
+
+[![Run on Repl.it](https://repl.it/badge/github/UhOhStinky12/engine)](https://repl.it/github/UhOhStinky12/engine)


### PR DESCRIPTION
This pull request adds a  badge to the . This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).

Fixes #

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
